### PR TITLE
Check for existing notification before commenting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ end
 message = ARGV.join(' ')
 
 coms = github.issue_comments(repo, pr["number"])
-duplicate = coms.find { |c| c["user"]["login"] == 'github-actions[bot]' and c["body"] == message }
+duplicate = coms.find { |c| c["user"]["login"] == "github-actions[bot]" && c["body"] == message }
 
 if duplicate
   puts "The PR already contains a database change notification"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,8 @@ if !pr
   exit(1)
 end
 
+message = ARGV.join(' ')
+
 coms = github.issue_comments(repo, pr["number"])
 duplicate = coms.find { |c| c["user"]["login"] == 'github-actions[bot]' and c["body"] == message }
 
@@ -37,5 +39,4 @@ if duplicate
   exit(0)
 end
 
-message = ARGV.join(' ')
 github.add_comment(repo, pr["number"], message)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,5 +29,13 @@ if !pr
   exit(1)
 end
 
+coms = github.issue_comments(repo, pr["number"])
+duplicate = coms.find { |c| c["user"]["login"] == 'github-actions[bot]' and c["body"] == message }
+
+if duplicate
+  puts "The PR already contains a database change notification"
+  exit(0)
+end
+
 message = ARGV.join(' ')
 github.add_comment(repo, pr["number"], message)


### PR DESCRIPTION
Not 100% sure that we want this but ...

Every time we push to an existing PR, the action gets triggered and a new comment is added to the PR even though the exact same comment was already written in the past.

This change checks for an identical existing comment in the PR before commenting again.
If an identical (same login and message body) comment is found, the action resolves correctly but without re-writing a duplicate comment.

When the comment contains a user notification (@ xxxx), this avoids spamming the user.

The reason why I'm hesitating is that there might be some cases where we actually want to repeat the notification (because the new schema change from the most recent push is actually important for example)

Proof that it works:

<img width="536" alt="Screen Shot 2019-08-02 at 15 00 48" src="https://user-images.githubusercontent.com/5332317/62371928-5f1b5900-b536-11e9-8756-edbae4b115ca.png">
