### PR TITLE
Support pull_request event types

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ require "json"
 require "octokit"
 
 json = File.read(ENV.fetch("GITHUB_EVENT_PATH"))
-push = JSON.parse(json)
+event = JSON.parse(json)
 
 github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
 
@@ -18,20 +18,25 @@ if ARGV.empty?
   exit(1)
 end
 
-repo = push["repository"]["full_name"]
-pulls = github.pull_requests(repo, state: "open")
+repo = event["repository"]["full_name"]
 
-push_head = push["after"]
-pr = pulls.find { |pr| pr["head"]["sha"] == push_head }
+if ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
+  pr_number = event["number"]
+else
+  pulls = github.pull_requests(repo, state: "open")
 
-if !pr
-  puts "Couldn't find an open pull request for branch with head at #{push_head}."
-  exit(1)
+  push_head = event["after"]
+  pr = pulls.find { |pr| pr["head"]["sha"] == push_head }
+
+  if !pr
+    puts "Couldn't find an open pull request for branch with head at #{push_head}."
+    exit(1)
+  end
+  pr_number = pr["number"]
 end
-
 message = ARGV.join(' ')
 
-coms = github.issue_comments(repo, pr["number"])
+coms = github.issue_comments(repo, pr_number)
 duplicate = coms.find { |c| c["user"]["login"] == "github-actions[bot]" && c["body"] == message }
 
 if duplicate
@@ -39,4 +44,4 @@ if duplicate
   exit(0)
 end
 
-github.add_comment(repo, pr["number"], message)
+github.add_comment(repo, pr_number, message)


### PR DESCRIPTION
I had a use case where I wanted to comment on a PR during a `pull_request` event type, so I added this support. This is completely backwards compatible with the existing behavior for `push` events.