### PR TITLE
Ignore user when checking for duplicate message

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ end
 coms = github.issue_comments(repo, pr_number)
 
 if check_duplicate_msg == "true"
-  duplicate = coms.find { |c| c["user"]["login"] == "github-actions[bot]" && c["body"] == message }
+  duplicate = coms.find { |c| c["body"] == message }
 
   if duplicate
     puts "The PR already contains this message"


### PR DESCRIPTION
If running as a different user with a personal access token, the "duplicate message check" will always fail.

If there is already a message on the PR with the _exact same body_, regardless of who said it, I think it seems reasonable to not have this bot do anything (or, if not, we could add an optional `username` argument too, but imo that's overkill)