### PR TITLE
Fix Ruby2 write permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM ruby:3-alpine3.13
 
 LABEL "com.github.actions.name"="Comment on PR"
 LABEL "com.github.actions.description"="Leaves a comment on an open PR matching a push event."


### PR DESCRIPTION
The issue is described here: [Stackoverflow](https://stackoverflow.com/questions/68243042/you-dont-have-write-permissions-for-the-usr-lib-ruby-gems-2-7-0-directory-alp)

EDIT: This also resolves the issue: #39 

To be short: ruby 2.7 docker image causes a write permission error and upgrade to 3.13 fixes it at this time.