### PR TITLE
Fix syntax error in entrypoint.sh.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ if check_duplicate_msg == "true"
   coms = github.issue_comments(repo, pr_number)
 
   duplicate = if duplicate_msg_pattern
-    coms.find { |c| (c["body"] =~ Regexp.new duplicate_msg_pattern) }
+    coms.find { |c| (c["body"] =~ Regexp.new(duplicate_msg_pattern)) }
   else
     coms.find { |c| c["body"] == message }
   end


### PR DESCRIPTION
Resolves this error:

    /entrypoint.sh:47: syntax error, unexpected local variable or method, expecting ')'
    ...egexp.new duplicate_msg_pattern) }
    ...          ^~~~~~~~~~~~~~~~~~~~~

---

I am not a Ruby expert so this may be wrong. If so, treat this code review as just a bug report.