### PR TITLE
Fix pattern based options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,11 @@ inputs:
   delete_prev_regex_msg:
     description: If not empty, all messages matching the given regex will be deleted.
     required: false
-    default: nil
+    default: ~
   duplicate_msg_pattern:
     description: Optional pattern to use when checking for duplicate message.
     required: false
+    default: ~
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,11 @@ inputs:
     required: false
     default: true
   delete_prev_regex_msg:
-    description: If not empty, all messages matching the given regex will be deleted.
+    description: If provided, all messages matching the given regex will be deleted.
     required: false
     default: ~
   duplicate_msg_pattern:
-    description: Optional pattern to use when checking for duplicate message.
+    description: If provided, the regex pattern will be used when checking for duplicate messages.
     required: false
     default: ~
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,8 +43,7 @@ end
 comments = github.issue_comments(repo, pr_number)
 
 if check_duplicate_msg == "true"
-  duplicate = if duplicate_msg_pattern
-    comments.find { |c| c["body"] =~ Regexp.new(duplicate_msg_pattern) }
+    duplicate = if !duplicate_msg_pattern.empty?
   else
     comments.find { |c| c["body"] == message }
   end
@@ -55,7 +54,7 @@ if check_duplicate_msg == "true"
   end
 end
 
-if delete_prev_regex_msg
+  if !delete_prev_regex_msg.empty?
   comments.each do |comment|
     if comment["body"].match(/#{delete_prev_regex_msg}/)
       github.delete_comment(repo, comment["id"])

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,6 +44,7 @@ comments = github.issue_comments(repo, pr_number)
 
 if check_duplicate_msg == "true"
     duplicate = if !duplicate_msg_pattern.empty?
+      comments.find { |c| c["body"].match(/#{duplicate_msg_pattern}/) }
   else
     comments.find { |c| c["body"] == message }
   end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,25 +40,27 @@ else
   pr_number = pr["number"]
 end
 
-comments = github.issue_comments(repo, pr_number)
+if !duplicate_msg_pattern.empty? || !delete_prev_regex_msg.empty?
+  comments = github.issue_comments(repo, pr_number)
 
-if check_duplicate_msg == "true"
+  if check_duplicate_msg == "true"
     duplicate = if !duplicate_msg_pattern.empty?
       comments.find { |c| c["body"].match(/#{duplicate_msg_pattern}/) }
-  else
-    comments.find { |c| c["body"] == message }
-  end
+    else
+      comments.find { |c| c["body"] == message }
+    end
 
-  if duplicate
-    puts "The PR already contains this message"
-    exit(0)
+    if duplicate
+      puts "The PR already contains this message"
+      exit(0)
+    end
   end
-end
 
   if !delete_prev_regex_msg.empty?
-  comments.each do |comment|
-    if comment["body"].match(/#{delete_prev_regex_msg}/)
-      github.delete_comment(repo, comment["id"])
+    comments.each do |comment|
+      if comment["body"].match(/#{delete_prev_regex_msg}/)
+        github.delete_comment(repo, comment["id"])
+      end
     end
   end
 end


### PR DESCRIPTION
In this PR, I fix a bug that's present in the action currently:

In Ruby, an empty string is truthy. As a result, passed a value of `""` or `"nil"`, these branches of the code will run. As a result, we need to change the default values of the input to `""` and check if the passed value is an empty string. No parsing is done to the values passed in as args so these are just strings. `"nil"` doesn't become `nil` and is truthy.

In `irb`, you can check the following:
``` shell
irb(main):024:1* if ""
irb(main):025:1*   puts "that string was truthy"
irb(main):026:0> end
(irb):26: warning: string literal in condition
that string was truthy
=> nil
irb(main):027:1* if "nil"
irb(main):028:1*   puts "that string was truthy"
irb(main):029:0> end
(irb):29: warning: string literal in condition
that string was truthy
=> nil
irb(main):030:1* if false
irb(main):031:1*   puts "that string was truthy"
irb(main):032:0> end
=> nil
```

In addition, I do some other clean up - make the option descriptions more consistent and restore an [optimization](5d96454a331858a93719d89649298fa5b6eaede5) that was [recently removed](7165e6dee795cea5fc31d3afbd66ad78c0168411).

