### PR TITLE
Fix sample workflow with actual versione tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: comment PR
-        uses: unsplash/comment-on-pr@1.3.0
+        uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The sample provided in the README reported a version number that didn't match any tag in the repo and resulted in:
```bash
Error: Unable to resolve action `unsplash/comment-on-pr@1.3.0`, unable to find version `1.3.0`
```