### PR TITLE
make `msg` optional, so the action can be used to delete comments too.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3-alpine3.13
 
-LABEL "com.github.actions.name"="Comment on PR with Delete"
+LABEL "com.github.actions.name"="Comment on PR"
 LABEL "com.github.actions.description"="Leaves a comment on an open PR matching a push event."
 LABEL "com.github.actions.repository"="https://github.com/Ronald-Baars/comment-on-pr-delete"
 LABEL "com.github.actions.maintainer"="Ronald Baars"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3-alpine3.13
 LABEL "com.github.actions.name"="Comment on PR"
 LABEL "com.github.actions.description"="Leaves a comment on an open PR matching a push event."
 LABEL "com.github.actions.repository"="https://github.com/unsplash/comment-on-pr"
-LABEL "com.github.actions.maintainer"="Ronald Baars"
+LABEL "com.github.actions.maintainer"="Aaron Klaassen <aaron@unsplash.com>"
 LABEL "com.github.actions.icon"="message-square"
 LABEL "com.github.actions.color"="blue"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3-alpine3.13
 
 LABEL "com.github.actions.name"="Comment on PR"
 LABEL "com.github.actions.description"="Leaves a comment on an open PR matching a push event."
-LABEL "com.github.actions.repository"="https://github.com/Ronald-Baars/comment-on-pr-delete"
+LABEL "com.github.actions.repository"="https://github.com/unsplash/comment-on-pr"
 LABEL "com.github.actions.maintainer"="Ronald Baars"
 LABEL "com.github.actions.icon"="message-square"
 LABEL "com.github.actions.color"="blue"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ruby:3-alpine3.13
 
-LABEL "com.github.actions.name"="Comment on PR"
+LABEL "com.github.actions.name"="Comment on PR with Delete"
 LABEL "com.github.actions.description"="Leaves a comment on an open PR matching a push event."
-LABEL "com.github.actions.repository"="https://github.com/unsplash/comment-on-pr"
-LABEL "com.github.actions.maintainer"="Aaron Klaassen <aaron@unsplash.com>"
+LABEL "com.github.actions.repository"="https://github.com/Ronald-Baars/comment-on-pr-delete"
+LABEL "com.github.actions.maintainer"="Ronald Baars"
 LABEL "com.github.actions.icon"="message-square"
 LABEL "com.github.actions.color"="blue"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Comment on PR via GitHub Action with delete
+# Comment on PR via GitHub Action
 
 A GitHub action to comment on the relevant open PR when a commit is pushed. If no msg is given, it can be used to delete previously posted messages.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Comment on PR via GitHub Action
 
-A GitHub action to comment on the relevant open PR when a commit is pushed. If no msg is given, it can be used to delete previously posted messages.
+A GitHub action to comment on the relevant open PR when a commit is pushed.
 
 ## Usage
 
@@ -23,8 +23,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: "Check out this message!"
+          msg: "Check out this message!"  # OPTIONAL
           check_for_duplicate_msg: false  # OPTIONAL
           delete_prev_regex_msg: "[0-9]"  # OPTIONAL
           duplicate_msg_pattern: "[A-Z]"  # OPTIONAL
 ```
+
+### Delete a message
+if the `msg` property is not set, the rest of the rules will still run, this means that previous messages can be removed.
+
+```yaml
+name: comment-on-pr example
+on: pull_request
+jobs:
+  example:
+    name: sample comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: comment PR
+        uses: unsplash/comment-on-pr@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          check_for_duplicate_msg: false  # OPTIONAL
+          delete_prev_regex_msg: "[0-9]"  # OPTIONAL
+          duplicate_msg_pattern: "[A-Z]"  # OPTIONAL
+```
+
+## Properties in "with"
+|                         | Required? | Type           | Description                                                                                             |
+|-------------------------|-----------|----------------|---------------------------------------------------------------------------------------------------------|
+| msg                     | no        | String         | The message that will be added to the PR                                                                |
+| check_for_duplicate_msg | no        | Boolean        | Wether to check for duplicate messages or not.                                                          |
+| delete_prev_regex_msg   | no        | Regex (string) | Regex pattern that will match existing comments. If a match is found, the old messages will be deleted. |
+| duplicate_msg_pattern   | no        | Regex (string) | Regex pattern that will match existing comments                                                         |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Comment on PR via GitHub Action
+# Comment on PR via GitHub Action with delete
 
-A GitHub action to comment on the relevant open PR when a commit is pushed.
+A GitHub action to comment on the relevant open PR when a commit is pushed. If no msg is given, it can be used to delete previously posted messages.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Comment on PR
+name: Comment on PR with delete
 author: Aaron Klaassen <aaron@unsplash.com>, updated by Ronald Baars
 description: Leaves a comment on an open PR matching a push event.
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Comment on PR with delete
-author: Aaron Klaassen <aaron@unsplash.com>, updated by Ronald Baars
+author: Aaron Klaassen <aaron@unsplash.com>
 description: Leaves a comment on an open PR matching a push event.
 branding:
   icon: 'message-square'  

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 inputs:
   msg: 
     description: Comment's message
-    required: true
+    required: false
   check_for_duplicate_msg:
     description: If false, action doesn't check for duplicate message.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Comment on PR
-author: Aaron Klaassen <aaron@unsplash.com>
+author: Aaron Klaassen <aaron@unsplash.com>, updated by Ronald Baars
 description: Leaves a comment on an open PR matching a push event.
 branding:
   icon: 'message-square'  

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Comment on PR with delete
+name: Comment on PR
 author: Aaron Klaassen <aaron@unsplash.com>
 description: Leaves a comment on an open PR matching a push event.
 branding:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ if !ENV["GITHUB_TOKEN"]
   exit(1)
 end
 
+github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
 message = ARGV[0]
 check_duplicate_msg = ARGV[1]
 delete_prev_regex_msg = ARGV[2]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,6 @@ event = JSON.parse(json)
 if !ENV["GITHUB_TOKEN"]
   puts "Missing GITHUB_TOKEN"
   exit(1)
-end
-
-github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
-
-
 message = ARGV[0]
 check_duplicate_msg = ARGV[1]
 delete_prev_regex_msg = ARGV[2]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,6 @@ end
 
 github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
 
-# if ARGV[0].empty?
-#   puts "Missing message argument."
-#   exit(1)
-# end
 
 message = ARGV[0]
 check_duplicate_msg = ARGV[1]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,10 @@ end
 
 github = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
 
-if ARGV[0].empty?
-  puts "Missing message argument."
-  exit(1)
-end
+# if ARGV[0].empty?
+#   puts "Missing message argument."
+#   exit(1)
+# end
 
 message = ARGV[0]
 check_duplicate_msg = ARGV[1]
@@ -65,4 +65,6 @@ if !duplicate_msg_pattern.empty? || !delete_prev_regex_msg.empty?
   end
 end
 
-github.add_comment(repo, pr_number, message)
+if !ARGV[0].empty?
+  github.add_comment(repo, pr_number, message)
+end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,8 @@ event = JSON.parse(json)
 if !ENV["GITHUB_TOKEN"]
   puts "Missing GITHUB_TOKEN"
   exit(1)
+end
+
 message = ARGV[0]
 check_duplicate_msg = ARGV[1]
 delete_prev_regex_msg = ARGV[2]


### PR DESCRIPTION
This PR adds the ability to use the delete functions without the need to post a new message. This is useful in our workflow where we use the comment to show a warning. When the issue is resolved, we need to remove the message without posting a new one.