### PR TITLE
Add support for for pull_request_review

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GitHub action to comment on the relevant open PR when a commit is pushed.
 
 - Requires the `GITHUB_TOKEN` secret.
 - Requires the comment's message in the `msg` parameter.
-- Supports `push` and `pull_request` event types.
+- Supports `push`, `pull_request` and `pull_request_review` event types.
 
 ### Sample workflow
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,8 @@ repo = event["repository"]["full_name"]
 
 if ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
   pr_number = event["number"]
+elsif ENV.fetch("GITHUB_EVENT_NAME") == "pull_request_review"
+  pr_number = event["pull_request"]["number"]
 else
   pulls = github.pull_requests(repo, state: "open")
 


### PR DESCRIPTION
Add support for for [`pull_request_review`](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request_review) by accessing `number` from [`pull_request` property](https://docs.github.com/en/rest/reference/pulls#get-a-pull-request)

### Testing

Before ❌
> Couldn't find an open pull request for branch with head at .

![image](https://user-images.githubusercontent.com/10026538/162242754-295f3343-56e6-4a31-bf55-3f41ea269ac3.png)

After ✅
![image](https://user-images.githubusercontent.com/10026538/162243094-a55aee79-5aea-4f88-82dc-d08358e5aea9.png)
![image](https://user-images.githubusercontent.com/10026538/162243532-8b2e3a5f-9a5f-4592-93f8-27c2999ad8ec.png)

Similar fixes could be applied for #38 #15