### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3-alpine3.13
+FROM ruby:3-alpine3.16
 
 LABEL "com.github.actions.name"="Comment on PR"
 LABEL "com.github.actions.description"="Leaves a comment on an open PR matching a push event."
@@ -7,7 +7,7 @@ LABEL "com.github.actions.maintainer"="Aaron Klaassen <aaron@unsplash.com>"
 LABEL "com.github.actions.icon"="message-square"
 LABEL "com.github.actions.color"="blue"
 
-RUN gem install octokit
+RUN gem install octokit -v 4.25.1
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
When using the Github action, the build of Dockerfile fails with following error:

>   ERROR:  Error installing octokit:
>   	The last version of octokit (>= 0) to support your Ruby & RubyGems was 4.25.1. Try installing it with `gem install octokit -v 4.25.1`
>   	octokit requires Ruby version >= 2.7.0. The current ruby version is 2.6.0.0.

The following commit fixes the build failure by defining octokit version (as also pumps up the version of ruby parent image) .